### PR TITLE
URLSession fixes

### DIFF
--- a/Foundation/NSString.swift
+++ b/Foundation/NSString.swift
@@ -27,7 +27,11 @@ func NSLocalizedString(_ key: String,
                        bundle: Bundle = Bundle.main,
                        value: String = "",
                        comment: String) -> String {
-    return bundle.localizedString(forKey: key, value: value, table: tableName)
+    #if os(Android)
+        return key
+    #else
+        return bundle.localizedString(forKey: key, value: value, table: tableName)
+    #endif
 }
 
 #if os(OSX) || os(iOS)

--- a/Foundation/URLSession/TaskRegistry.swift
+++ b/Foundation/URLSession/TaskRegistry.swift
@@ -115,4 +115,8 @@ extension URLSession._TaskRegistry {
         }
         return b
     }
+    
+    func containsBehaviour(for task: URLSessionTask) -> Bool {
+        return behaviours[task.taskIdentifier] != nil
+    }
 }

--- a/Foundation/URLSession/URLSession.swift
+++ b/Foundation/URLSession/URLSession.swift
@@ -546,6 +546,10 @@ internal extension URLSession {
     }
 
     func behaviour(for task: URLSessionTask) -> _TaskBehaviour {
+        guard taskRegistry.containsBehaviour(for: task) else {
+            return .noDelegate
+        }
+        
         switch taskRegistry.behaviour(for: task) {
         case .dataCompletionHandler(let c): return .dataCompletionHandler(c)
         case .downloadCompletionHandler(let c): return .downloadCompletionHandler(c)


### PR DESCRIPTION
- If there is no task delegate in task registry, return `. noDelegate`
- Avoid using bundle in Android