### PR TITLE
Support digest and ntlm auth

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.c
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.c
@@ -89,6 +89,9 @@ CFURLSessionEasyCode CFURLSession_easy_setopt_int(CFURLSessionEasyHandle _Nonnul
 CFURLSessionEasyCode CFURLSession_easy_setopt_long(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, long a) {
     return MakeEasyCode(curl_easy_setopt(curl, option.value, a));
 }
+CFURLSessionEasyCode CFURLSession_easy_setopt_unsigned_long(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, unsigned long a) {
+    return MakeEasyCode(curl_easy_setopt(curl, option.value, a));
+}
 CFURLSessionEasyCode CFURLSession_easy_setopt_int64(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, long long a) {
     return MakeEasyCode(curl_easy_setopt(curl, option.value, (int64_t)a));
 }
@@ -562,6 +565,10 @@ CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void) {
     return v;
 }
 
+unsigned long const CFURLSessionAUTH_NONE = CURLAUTH_NONE;
+unsigned long const CFURLSessionAUTH_BASIC = CURLAUTH_BASIC;
+unsigned long const CFURLSessionAUTH_DIGEST = CURLAUTH_DIGEST;
+unsigned long const CFURLSessionAUTH_NTLM = CURLAUTH_NTLM;
 
 int const CFURLSessionWriteFuncPause = CURL_WRITEFUNC_PAUSE;
 int const CFURLSessionReadFuncPause = CURL_READFUNC_PAUSE;

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -551,6 +551,10 @@ typedef struct CFURLSessionCurlVersion {
 } CFURLSessionCurlVersion;
 CF_EXPORT CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void);
 
+CF_EXPORT unsigned long const CFURLSessionAUTH_NONE;
+CF_EXPORT unsigned long const CFURLSessionAUTH_BASIC;
+CF_EXPORT unsigned long const CFURLSessionAUTH_DIGEST;
+CF_EXPORT unsigned long const CFURLSessionAUTH_NTLM;
 
 CF_EXPORT int const CFURLSessionWriteFuncPause;
 CF_EXPORT int const CFURLSessionReadFuncPause;
@@ -582,6 +586,7 @@ CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_fptr(CFURLSessionEasyHan
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_ptr(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, void *_Nullable a);
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_int(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, int a);
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_long(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, long a);
+CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_unsigned_long(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, unsigned long a);
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_int64(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, long long a);
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_wc(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, size_t(*_Nonnull a)(char *_Nonnull, size_t, size_t, void *_Nullable));
 CF_EXPORT CFURLSessionEasyCode CFURLSession_easy_setopt_fwc(CFURLSessionEasyHandle _Nonnull curl, CFURLSessionOption option, size_t(*_Nonnull a)(char *_Nonnull, size_t, size_t, void *_Nullable));

--- a/DarwinCompatibilityTests.xcodeproj/project.pbxproj
+++ b/DarwinCompatibilityTests.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		B9ED84FD23641F7000A58AF2 /* DarwinShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F3269E1FC714DD003C3599 /* DarwinShims.swift */; };
 		B9F137A120B998D0000B7577 /* xdgTestHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = B917D31C20B0DB8B00728EE0 /* xdgTestHelper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B9F4492A2483FA1E00B30F02 /* TestNSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F449292483FA1E00B30F02 /* TestNSURL.swift */; };
+		C2BFC7B62568222600EDEA0B /* TestURLSessionRealServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BFC7B52568222500EDEA0B /* TestURLSessionRealServer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -312,6 +313,7 @@
 		B9C89EDF1F6BF79000087AF4 /* TestFoundation */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestFoundation; path = ../TestFoundation; sourceTree = "<group>"; };
 		B9F3269E1FC714DD003C3599 /* DarwinShims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarwinShims.swift; sourceTree = "<group>"; };
 		B9F449292483FA1E00B30F02 /* TestNSURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestNSURL.swift; path = Tests/Foundation/Tests/TestNSURL.swift; sourceTree = "<group>"; };
+		C2BFC7B52568222500EDEA0B /* TestURLSessionRealServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestURLSessionRealServer.swift; path = Tests/Foundation/Tests/TestURLSessionRealServer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -439,6 +441,7 @@
 				B94B07892401849800B244E8 /* TestURLResponse.swift */,
 				B94B07A52401849A00B244E8 /* TestURLSession.swift */,
 				B94B079F2401849A00B244E8 /* TestURLSessionFTP.swift */,
+				C2BFC7B52568222500EDEA0B /* TestURLSessionRealServer.swift */,
 				B94B07742401849600B244E8 /* TestUserDefaults.swift */,
 				B94B077A2401849700B244E8 /* TestUtils.swift */,
 				B94B077B2401849700B244E8 /* TestUUID.swift */,
@@ -697,6 +700,7 @@
 				B94B07E22401849B00B244E8 /* TestPropertyListEncoder.swift in Sources */,
 				B94B07E32401849B00B244E8 /* TestHTTPCookie.swift in Sources */,
 				B94B07E42401849B00B244E8 /* TestAffineTransform.swift in Sources */,
+				C2BFC7B62568222600EDEA0B /* TestURLSessionRealServer.swift in Sources */,
 				B94B07E52401849B00B244E8 /* TestNSNull.swift in Sources */,
 				B94B07E62401849B00B244E8 /* TestUnit.swift in Sources */,
 				B94B07E72401849B00B244E8 /* TestISO8601DateFormatter.swift in Sources */,

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 		BDFDF0A71DFF5B3E00C04CC5 /* TestPersonNameComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFDF0A61DFF5B3E00C04CC5 /* TestPersonNameComponents.swift */; };
 		BF85E9D81FBDCC2000A79793 /* TestHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF85E9D71FBDCC2000A79793 /* TestHost.swift */; };
 		BF8E65311DC3B3CB005AB5C3 /* TestNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */; };
+		C2BFC7952568202C00EDEA0B /* TestURLSessionRealServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BFC7942568202B00EDEA0B /* TestURLSessionRealServer.swift */; };
 		C7DE1FCC21EEE67200174F35 /* TestUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DE1FCB21EEE67200174F35 /* TestUUID.swift */; };
 		CC5249C01D341D23007CB54D /* TestUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */; };
 		CD1C7F7D1E303B47008E331C /* TestNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C7F7C1E303B47008E331C /* TestNSError.swift */; };
@@ -1123,6 +1124,7 @@
 		BF85E9D71FBDCC2000A79793 /* TestHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHost.swift; sourceTree = "<group>"; };
 		BF8E65301DC3B3CB005AB5C3 /* TestNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNotification.swift; sourceTree = "<group>"; };
 		C2A9D75B1C15C08B00993803 /* TestNSUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNSUUID.swift; sourceTree = "<group>"; };
+		C2BFC7942568202B00EDEA0B /* TestURLSessionRealServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestURLSessionRealServer.swift; sourceTree = "<group>"; };
 		C7DE1FCB21EEE67200174F35 /* TestUUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUUID.swift; sourceTree = "<group>"; };
 		C93559281C12C49F009FD6A9 /* TestAffineTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAffineTransform.swift; sourceTree = "<group>"; };
 		CC5249BF1D341D23007CB54D /* TestUnitConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUnitConverter.swift; sourceTree = "<group>"; };
@@ -1876,6 +1878,7 @@
 				7A7D6FBA1C16439400957E2E /* TestURLResponse.swift */,
 				5B1FD9E21D6D17B80080E83C /* TestURLSession.swift */,
 				616068F4225DE606004FCC54 /* TestURLSessionFTP.swift */,
+				C2BFC7942568202B00EDEA0B /* TestURLSessionRealServer.swift */,
 				555683BC1C1250E70041D4C6 /* TestUserDefaults.swift */,
 				5B6F17961C48631C00935030 /* TestUtils.swift */,
 				C7DE1FCB21EEE67200174F35 /* TestUUID.swift */,
@@ -3126,6 +3129,7 @@
 				D5C40F331CDA1D460005690C /* TestOperationQueue.swift in Sources */,
 				616068F3225DE5C2004FCC54 /* FTPServer.swift in Sources */,
 				BDBB65901E256BFA001A7286 /* TestEnergyFormatter.swift in Sources */,
+				C2BFC7952568202C00EDEA0B /* TestURLSessionRealServer.swift in Sources */,
 				5B13B32F1C582D4C00651CE2 /* TestNSGeometry.swift in Sources */,
 				7D0DE86E211883F500540061 /* TestDateComponents.swift in Sources */,
 				5B13B3351C582D4C00651CE2 /* TestNSKeyedUnarchiver.swift in Sources */,

--- a/Sources/FoundationNetworking/URLProtectionSpace.swift
+++ b/Sources/FoundationNetworking/URLProtectionSpace.swift
@@ -355,6 +355,8 @@ extension _HTTPURLProtocol._HTTPMessage._Challenge {
             return NSURLAuthenticationMethodHTTPBasic
         } else if authScheme.caseInsensitiveCompare(_HTTPURLProtocol._HTTPMessage._Challenge.AuthSchemeDigest) == .orderedSame {
             return NSURLAuthenticationMethodHTTPDigest
+        } else if authScheme.caseInsensitiveCompare(_HTTPURLProtocol._HTTPMessage._Challenge.AuthSchemeNTLM) == .orderedSame {
+            return NSURLAuthenticationMethodNTLM
         } else {
             return nil
         }

--- a/Sources/FoundationNetworking/URLRequest.swift
+++ b/Sources/FoundationNetworking/URLRequest.swift
@@ -71,6 +71,9 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     // to explicitly 60 then the precedence should be given to URLRequest.timeoutInterval.
     internal var isTimeoutIntervalSet = false
     
+    internal var authMethod: String?
+    internal var credential: URLCredential?
+    
     /// Returns the timeout interval of the receiver.
     /// - discussion: The timeout interval specifies the limit on the idle
     /// interval allotted to a request in the process of loading. The "idle

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -431,6 +431,18 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         easyHandle.set(requestMethod: request.httpMethod ?? "GET")
         // Always set the status as it may change if a HEAD is converted to a GET.
         easyHandle.set(noBody: request.httpMethod == "HEAD")
+        
+        if let authMethod = request.authMethod {
+            let authMethodWasSet = easyHandle.set(authMethod: authMethod)
+            if !authMethodWasSet {
+                NSLog("\(authMethod) is not supported")
+            }
+            if let credential = request.credential {
+                let username = credential.user ?? ""
+                let password = credential.password ?? ""
+                easyHandle.set(username: username, password: password)
+            }
+        }
     }
 
     /// What action to take

--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -662,6 +662,22 @@ extension _NativeProtocol {
     }
 }
 
+extension _NativeProtocol {
+    
+    func prepareAuthenticationRequestReuse() {
+        // Without EasyHandle reuse we have bugs:
+        //  1. Digest: curl use 2 requests intead of 1 to authenticate
+        //  2. Digest + Post + urlRequest.setValue("chunked", forHTTPHeaderField: "Transfer-Encoding")
+        //     curl doesn't send all data and as a result connection disconnects with timeout
+        //     (TestURLSessionRealServer.test_dataTaskWithDigestAuth_InputStream)
+        // This allows to reuse _NativeProtocol and its EasyHandle
+        if case .taskCompleted = internalState {
+            self.internalState = .initial
+        }
+    }
+
+}
+
 extension URLSession {
     static func printDebug(_ text: @autoclosure () -> String) {
         guard enableDebugOutput else { return }

--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -880,7 +880,11 @@ extension _ProtocolClient : URLProtocolClient {
                 } else {
                     task._lastCredentialUsedFromStorageDuringAuthentication = nil
                 }
-                task._protocolStorage = .existing(_HTTPURLProtocol(task: task, cachedResponse: nil, client: nil))
+                if let urlProtocol = `protocol` as? _HTTPURLProtocol {
+                    urlProtocol.prepareAuthenticationRequestReuse()
+                } else {
+                    task._protocolStorage = .existing(_HTTPURLProtocol(task: task, cachedResponse: nil, client: nil))
+                }
             }
             if case .stream(let stream) = task.knownBody, stream.streamStatus != .notOpen {
                 task.knownBody = nil
@@ -928,7 +932,12 @@ extension _ProtocolClient : URLProtocolClient {
                 }
             }
         } else {
-            attemptProceedingWithDefaultCredential()
+            // This function is called from _NativeProtocol.completeTask.
+            // _NativeProtocol.internalState will be set to .taskCompleted after execution of this function.
+            // Seems like a bug. To fix it, I simulate same flow that we have with task delegate.
+            session.delegateQueue.addOperation {
+                attemptProceedingWithDefaultCredential()
+            }
         }
     }
 
@@ -1062,7 +1071,8 @@ extension URLSessionTask {
     static func authHandler(for authScheme: String) -> _AuthHandler? {
         let handlers: [String : _AuthHandler] = [
             NSURLAuthenticationMethodHTTPBasic : basicAuth,
-            NSURLAuthenticationMethodHTTPDigest: digestAuth
+            NSURLAuthenticationMethodHTTPDigest: digestAuth,
+            NSURLAuthenticationMethodNTLM      : ntlmAuth,
         ]
         return handlers[authScheme]
     }
@@ -1070,16 +1080,23 @@ extension URLSessionTask {
     //Authentication handlers
     static func basicAuth(_ task: URLSessionTask, _ disposition: URLSession.AuthChallengeDisposition, _ credential: URLCredential?) {
         //TODO: Handle disposition. For now, we default to .useCredential
-        let user = credential?.user ?? ""
-        let password = credential?.password ?? ""
-        let encodedString = "\(user):\(password)".data(using: .utf8)?.base64EncodedString()
         task.authRequest = task.originalRequest
-        task.authRequest?.setValue("Basic \(encodedString!)", forHTTPHeaderField: "Authorization")
+        task.authRequest?.authMethod = NSURLAuthenticationMethodHTTPBasic
+        task.authRequest?.credential = credential
     }
 
     static func digestAuth(_ task: URLSessionTask, _ disposition: URLSession.AuthChallengeDisposition, _ credential: URLCredential?) {
-        fatalError("The URLSession swift-corelibs-foundation implementation doesn't currently handle digest authentication.")
+        task.authRequest = task.originalRequest
+        task.authRequest?.authMethod = NSURLAuthenticationMethodHTTPDigest
+        task.authRequest?.credential = credential
     }
+    
+    static func ntlmAuth(_ task: URLSessionTask, _ disposition: URLSession.AuthChallengeDisposition, _ credential: URLCredential?) {
+        task.authRequest = task.originalRequest
+        task.authRequest?.authMethod = NSURLAuthenticationMethodNTLM
+        task.authRequest?.credential = credential
+    }
+
 }
 
 extension URLProtocol {

--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -282,6 +282,28 @@ extension _EasyHandle {
         CFURLSession_easy_getinfo_double(rawHandle, CFURLSessionInfoTOTAL_TIME, &timeSpent)
         return timeSpent / 1000
     }
+    
+    func set(authMethod: String) -> Bool {
+        var method = CFURLSessionAUTH_NONE
+        switch authMethod {
+        case NSURLAuthenticationMethodHTTPBasic:
+            method = CFURLSessionAUTH_BASIC
+        case NSURLAuthenticationMethodHTTPDigest:
+            method = CFURLSessionAUTH_DIGEST
+        case NSURLAuthenticationMethodNTLM:
+            method = CFURLSessionAUTH_NTLM
+        default:
+            return false
+        }
+        CFURLSession_easy_setopt_unsigned_long(rawHandle, CFURLSessionOptionHTTPAUTH, method)
+        return true
+    }
+    
+    func set(username: String, password: String) {
+        "\(username):\(password)".withCString {
+            CFURLSession_easy_setopt_ptr(rawHandle, CFURLSessionOptionUSERPWD, UnsafeMutablePointer(mutating: $0))
+        }
+    }
 
 }
 

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -103,6 +103,7 @@ target_sources(TestFoundation PRIVATE
   Tests/TestURLResponse.swift
   Tests/TestURLSession.swift
   Tests/TestURLSessionFTP.swift
+  Tests/TestURLSessionRealServer.swift
   Tests/TestURL.swift
   Tests/TestUserDefaults.swift
   Tests/TestUtils.swift

--- a/Tests/Foundation/Tests/TestURLSessionRealServer.swift
+++ b/Tests/Foundation/Tests/TestURLSessionRealServer.swift
@@ -1,0 +1,457 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+let loremIpsum = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+"""
+
+let httpBinCredentails = URLCredential(user: "user", password: "passwd", persistence: URLCredential.Persistence.none)
+
+class TestURLSessionRealServer: XCTestCase {
+    static var allTests: [(String, (TestURLSessionRealServer) -> () throws -> Void)] {
+        return [
+            ("test_dataTaskWithHttpBody", test_dataTaskWithHttpBody),
+            ("test_dataTaskWithHttpInputStream", test_dataTaskWithHttpInputStream), // HTTPBin doesn't support chunked transfer encoding
+            ("test_dataTaskWithBasicAuth", test_dataTaskWithBasicAuth),
+            ("test_dataTaskWithBasicAuth_InputStream", test_dataTaskWithBasicAuth_InputStream),
+            ("test_dataTaskWithDigestAuth", test_dataTaskWithDigestAuth),
+            ("test_dataTaskWithDigestAuth_InputStream", test_dataTaskWithDigestAuth_InputStream),
+            ("test_dataTaskWithDigestAuth_CredentialOnce", test_dataTaskWithDigestAuth_CredentialOnce),
+            ("test_dataTaskWithDigestAuth_AuthChallenges", test_dataTaskWithDigestAuth_AuthChallenges),
+//            ("test_badCertificate", test_badCertificate)
+        ]
+    }
+
+    override func setUp() {
+        #if os(Windows)
+        _putenv("URLSessionDebugLibcurl=TRUE")
+        #else
+        setenv("URLSessionDebugLibcurl", "TRUE", 1)
+        #endif
+    }
+
+    func test_dataTaskWithHttpBody() {
+        let delegate = HTTPBinResponseDelegateJSON<HTTPBinResponse>()
+
+        let urlString = "http://httpbin.org/post"
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+        let data = loremIpsum.data(using: .utf8)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = data
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.data == loremIpsum)
+    }
+
+    /*
+    func test_badCertificate() {
+        let delegate = HTTPBinResponseDelegateAuthOwnCert<HTTPBinAuthResponse>()
+
+        let certificateFailures = ["self-signed", "expired", "wrong.host", "untrusted-root", "revoked", "pinning-test"]
+
+        for certFailure in certificateFailures {
+            let url = URL(string: "https://\(certFailure).badssl.com/")!
+            let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+            var urlRequest = URLRequest(url: url)
+            urlRequest.httpMethod = "GET"
+            urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+            urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+            let urlTask = urlSession.dataTask(with: urlRequest)
+            urlTask.resume()
+
+            delegate.semaphore.wait()
+            XCTAssertTrue(urlTask.response != nil)
+            if (urlTask.response != nil) {
+                XCTAssertTrue(urlTask.response is HTTPURLResponse)
+                XCTAssertTrue((urlTask.response as! HTTPURLResponse).statusCode == 200)
+            }
+        }
+    }
+    */
+    
+    func test_dataTaskWithHttpInputStream() {
+        let delegate = HTTPBinResponseDelegateJSON<HTTPBinResponse>()
+
+        let urlString = "http://httpbin.org/post"
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+
+        guard let data = loremIpsum.data(using: .utf8) else {
+            XCTFail()
+            return
+        }
+
+        let inputStream = InputStream(data: data)
+
+        urlRequest.httpBodyStream = inputStream
+
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("chunked", forHTTPHeaderField: "Transfer-Encoding")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.data == loremIpsum)
+    }
+
+    func test_dataTaskWithBasicAuth() {
+        let delegate = HTTPBinResponseDelegateAuth<HTTPBinAuthResponse>()
+
+        let urlString = "http://httpbin.org/basic-auth/user/passwd"
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+        urlTask.resume()
+
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.authenticated ?? false)
+        XCTAssertTrue(delegate.response?.user == httpBinCredentails.user)
+    }
+    
+    func test_dataTaskWithBasicAuth_InputStream() {
+        let delegate = HTTPBinResponseDelegateAuth<HTTPBinResponse>()
+
+        let urlString = "https://rdauthtest.000webhostapp.com/basic_post.php"
+        // To view source code open - https://rdauthtest.000webhostapp.com/basic_post.txt
+
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+
+        guard let data = loremIpsum.data(using: .utf8) else {
+            XCTFail()
+            return
+        }
+
+        let inputStream = InputStream(data: data)
+
+        urlRequest.httpBodyStream = inputStream
+
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("chunked", forHTTPHeaderField: "Transfer-Encoding")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertEqual(delegate.lastAuthenticationMethod, NSURLAuthenticationMethodHTTPBasic)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.data == loremIpsum)
+    }
+
+    func test_dataTaskWithDigestAuth() {
+        let delegate = HTTPBinResponseDelegateAuth<HTTPBinAuthResponse>()
+        let urlTask = buildDigestAuthURLTaskForHTTPBin(delegate)
+
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.authenticated ?? false)
+        XCTAssertTrue(delegate.response?.user == httpBinCredentails.user)
+    }
+    
+    func test_dataTaskWithDigestAuth_InputStream() {
+        let delegate = HTTPBinResponseDelegateAuth<HTTPBinResponse>()
+
+        let urlString = "https://rdauthtest.000webhostapp.com/digest_post.php"
+        // To view source code open - https://rdauthtest.000webhostapp.com/digest_post.txt
+
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+
+        guard let data = loremIpsum.data(using: .utf8) else {
+            XCTFail()
+            return
+        }
+
+        let inputStream = InputStream(data: data)
+
+        urlRequest.httpBodyStream = inputStream
+
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("chunked", forHTTPHeaderField: "Transfer-Encoding")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertEqual(delegate.lastAuthenticationMethod, NSURLAuthenticationMethodHTTPDigest)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.data == loremIpsum)
+    }
+
+    func test_dataTaskWithDigestAuth_CredentialOnce() {
+        let delegate = HTTPBinResponseDelegateAuth_CredentialsOnce()
+        let urlTask = buildDigestAuthURLTaskForHTTPBin(delegate)
+
+        urlTask.resume()
+
+        delegate.semaphore.wait()
+
+        XCTAssertTrue(urlTask.response != nil)
+        XCTAssertTrue(delegate.response != nil)
+        XCTAssertTrue(delegate.response?.authenticated ?? false)
+        XCTAssertTrue(delegate.response?.user == httpBinCredentails.user)
+    }
+
+    func test_dataTaskWithDigestAuth_AuthChallenges() {
+        // Cancel
+        var delegate = HTTPBinResponseDelegateAuth_AuthChallenges_Counter(.cancelAuthenticationChallenge)
+        var urlTask = buildDigestAuthURLTaskForHTTPBin(delegate)
+        urlTask.resume()
+        delegate.semaphore.wait()
+        XCTAssertTrue(delegate.count == 1)
+
+        // Reject
+        delegate = HTTPBinResponseDelegateAuth_AuthChallenges_Counter(.rejectProtectionSpace)
+        urlTask = buildDigestAuthURLTaskForHTTPBin(delegate)
+        urlTask.resume()
+        delegate.semaphore.wait()
+        XCTAssertTrue(delegate.count == 1) // asked for more than 1 protection space
+        XCTAssertEqual(urlTask.state, URLSessionTask.State.completed)
+
+        // Default
+        delegate = HTTPBinResponseDelegateAuth_AuthChallenges_Counter(.performDefaultHandling)
+        urlTask = buildDigestAuthURLTaskForHTTPBin(delegate)
+        urlTask.resume()
+        delegate.semaphore.wait()
+        XCTAssertTrue(delegate.count == 1)
+    }
+
+    func buildDigestAuthURLTaskForHTTPBin(_ delegate: HTTPBinResponseDelegate<HTTPBinAuthResponse>) -> URLSessionTask {
+        let urlString = "http://httpbin.org/digest-auth/auth/user/passwd/MD5/never"
+        let url = URL(string: urlString)!
+        let urlSession = URLSession(configuration: URLSessionConfiguration.default, delegate: delegate, delegateQueue: nil)
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("en-us", forHTTPHeaderField: "Accept-Language")
+        urlRequest.setValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+        let urlTask = urlSession.dataTask(with: urlRequest)
+
+        return urlTask
+    }
+
+    class HTTPBinResponseDelegateAuth<T: Codable>: HTTPBinResponseDelegateJSON<T> {
+        override func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            print("didReceive challenge")
+            resetOutput()
+            lastAuthenticationMethod = challenge.protectionSpace.authenticationMethod
+            completionHandler(.useCredential, httpBinCredentails)
+        }
+    }
+    
+    /*
+    class HTTPBinResponseDelegateAuthOwnCert<T: Codable>: HTTPBinResponseDelegateJSON<T> {
+        override func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            #if DARWIN_COMPATIBILITY_TESTS
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+                let credential = URLCredential.init(trust: challenge.protectionSpace.serverTrust!)
+                completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
+            }
+            else {
+                completionHandler(.useCredential, httpBinCredentails)
+            }
+            #else
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+                completionHandler(.useCredential, URLCredential.init(trust: true))
+            }
+            else {
+                completionHandler(.useCredential, httpBinCredentails)
+            }
+            #endif
+        }
+    }
+    */
+
+    class HTTPBinResponseDelegateAuth_AuthChallenges_Counter: HTTPBinResponseDelegateJSON<HTTPBinAuthResponse> {
+        let challenge: URLSession.AuthChallengeDisposition
+        public var count = 0
+
+        init(_ challenge: URLSession.AuthChallengeDisposition) {
+            self.challenge = challenge
+        }
+
+        override func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            print("didReceive challenge")
+            resetOutput()
+            lastAuthenticationMethod = challenge.protectionSpace.authenticationMethod
+            count += 1
+            completionHandler(self.challenge, httpBinCredentails)
+        }
+    }
+
+    class HTTPBinResponseDelegateAuth_CredentialsOnce: HTTPBinResponseDelegateJSON<HTTPBinAuthResponse> {
+        var tryCount = 0
+
+        override func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            print("didReceive challenge")
+            resetOutput()
+            lastAuthenticationMethod = challenge.protectionSpace.authenticationMethod
+            
+            if tryCount > 0 {
+                completionHandler(.useCredential, nil)
+            } else {
+                completionHandler(.useCredential, httpBinCredentails)
+            }
+            tryCount += 1
+        }
+    }
+
+    class HTTPBinResponseDelegate<T>: NSObject, URLSessionDataDelegate, URLSessionTaskDelegate {
+        let semaphore = DispatchSemaphore(value: 0)
+        var outputStream = OutputStream.toMemory()
+        var response: T?
+
+        override init() {
+            outputStream.open()
+        }
+
+        deinit {
+            outputStream.close()
+        }
+        
+        func resetOutput() {
+            outputStream.close()
+            outputStream = OutputStream.toMemory()
+            outputStream.open()
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+
+        }
+
+        public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            _ = data.withUnsafeBytes({ (bytes: UnsafePointer<UInt8>) in
+                outputStream.write(bytes, maxLength: data.count)
+            })
+        }
+
+        public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            if let data = outputStream.property(forKey: .dataWrittenToMemoryStreamKey) as? Data {
+                response = parseResposne(data: data)
+            }
+            semaphore.signal()
+        }
+
+
+        // Used only for httpBodyStream
+        public func urlSession(_ session: URLSession, task: URLSessionTask, needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
+            guard let data = loremIpsum.data(using: .utf8) else {
+                XCTFail()
+                return
+            }
+            let inputStream = InputStream(data: data)
+            completionHandler(inputStream)
+        }
+
+        public func parseResposne(data: Data) -> T? {
+            fatalError("")
+        }
+
+
+        func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+            // We've got an error
+            if let err = error {
+                print("Error: \(err.localizedDescription)")
+            } else {
+                print("Error. Giving up")
+            }
+            //PlaygroundPage.current.finishExecution()
+        }
+    }
+
+    class HTTPBinResponseDelegateString: HTTPBinResponseDelegate<String> {
+        override func parseResposne(data: Data) -> String? {
+            return String(data: data, encoding: .utf8)
+        }
+    }
+
+    class HTTPBinResponseDelegateJSON<T: Codable>: HTTPBinResponseDelegate<T> {
+        var lastAuthenticationMethod: String?
+        
+        override func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        }
+
+        override func parseResposne(data: Data) -> T? {
+            let str = String(data: data, encoding: .utf8) ?? " --- "
+            print("Response data: \(str)")
+            return try? JSONDecoder().decode(T.self, from: data)
+        }
+    }
+
+    struct HTTPBinResponse: Codable {
+        let data: String
+        let headers: [String: String]
+        let origin: String
+        let url: String
+    }
+
+    struct HTTPBinAuthResponse: Codable {
+        let authenticated: Bool
+        let user: String
+    }
+}
+

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -99,6 +99,7 @@ var allTestCases = [
     testCase(TestURLResponse.allTests),
     testCase(TestHTTPURLResponse.allTests),
     testCaseExpectedToFail(TestURLSession.allTests, "URLSession test interdependencies are causing intermittent CI issues."),
+    testCase(TestURLSessionRealServer.allTests),
     testCase(TestNSUUID.allTests),
     testCase(TestUUID.allTests),
     testCase(TestNSValue.allTests),


### PR DESCRIPTION
Add support NSURLAuthenticationMethodHTTPDigest and NSURLAuthenticationMethodNTLM
I use same method for basicAuth to unify codebase :) Maybe this part should be reverted.